### PR TITLE
add case when bcryptjs.compare does not return error but also returns…

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -147,7 +147,7 @@ export const login = async (
     .exec()
     .then((users) => {
       if (!users.length) {
-        return res.status(404).json({
+        return res.status(401).json({
           message: "Account with that login and password does not exist",
         });
       }
@@ -199,11 +199,16 @@ export const login = async (
               "Login",
               "Could not sign tokens when trying to login"
             );
-            return res.status(500).json({
+            return res.status(401).json({
               message: "Unauthorized",
               error,
             });
           }
+        } else {
+          return res.status(401).json({
+            message: "Account with that login and password does not exist",
+            error,
+          });
         }
       });
     })


### PR DESCRIPTION
… false as a result - wrong credentials case